### PR TITLE
Add GitHub Action workflow for vfrmap

### DIFF
--- a/.github/workflows/vfrmap.yml
+++ b/.github/workflows/vfrmap.yml
@@ -27,9 +27,9 @@ jobs:
         go get -v -t -d ./...
     
     - name: download and generate vfrmap html dependencies
-      run: |
-        cd vfrmap
-        make generate
+      working-directory: ./vfrmap
+      run: make generate
 
     - name: build
+      working-directory: ./vfrmap
       run: go build -v .

--- a/.github/workflows/vfrmap.yml
+++ b/.github/workflows/vfrmap.yml
@@ -1,0 +1,35 @@
+name: vfrmap
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: set up go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+
+    - name: checkout repository
+      uses: actions/checkout@v2
+
+    - name: get go dependencies
+      run: |
+        go get -v -t -d ./...
+    
+    - name: download and generate vfrmap html dependencies
+      run: |
+        cd vfrmap
+        make generate
+
+    - name: build
+      run: go build -v .


### PR DESCRIPTION
This PR adds a GitHub Action workflow that will build the `vfrmap` project on any master commit or PR.

Note: the action file will not work until #54 is merged, because it will run the `make generate` task from the added Makefile in #54.