### PR TITLE
Added TransmitClientEvent

### DIFF
--- a/examples/transmit_event/main.go
+++ b/examples/transmit_event/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/lian/msfs2020-go/simconnect"
+)
+
+type Events struct {
+	ToggleNavLights simconnect.DWORD
+	ToggleAPMaster  simconnect.DWORD
+}
+
+func main() {
+	s, err := simconnect.New("Transmit Event")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Connected to Flight Simulator!")
+
+	events := &Events{
+		ToggleNavLights: s.GetEventID(),
+		ToggleAPMaster:  s.GetEventID(),
+	}
+
+	err = s.MapClientEventToSimEvent(events.ToggleNavLights, "TOGGLE_NAV_LIGHTS")
+	if err != nil {
+		panic(err)
+	}
+
+	err = s.MapClientEventToSimEvent(events.ToggleAPMaster, "AP_MASTER")
+	if err != nil {
+		panic(err)
+	}
+
+	for {
+
+		err = s.TransmitClientID(events.ToggleNavLights, 0)
+		if err != nil {
+			panic(err)
+		}
+
+		err = s.TransmitClientID(events.ToggleAPMaster, 0)
+		if err != nil {
+			panic(err)
+		}
+
+		time.Sleep(2000 * time.Millisecond)
+
+	}
+
+	fmt.Println("close")
+
+	if err = s.Close(); err != nil {
+		panic(err)
+	}
+}

--- a/simconnect/defs.go
+++ b/simconnect/defs.go
@@ -64,6 +64,12 @@ const GROUP_PRIORITY_STANDARD DWORD = 1900000000       // standard priority
 const GROUP_PRIORITY_DEFAULT DWORD = 2000000000        // default priority
 const GROUP_PRIORITY_LOWEST DWORD = 4000000000         // priorities lower than this will be ignored
 
+// Event flag values
+const SIMCONNECT_EVENT_FLAG_DEFAULT DWORD = 0x00000000
+const SIMCONNECT_EVENT_FLAG_FAST_REPEAT_TIMER DWORD = 0x00000001   // set event repeat timer to simulate fast repeat
+const SIMCONNECT_EVENT_FLAG_SLOW_REPEAT_TIMER DWORD = 0x00000002   // set event repeat timer to simulate slow repeat
+const SIMCONNECT_EVENT_FLAG_GROUPID_IS_PRIORITY DWORD = 0x00000010 // interpret GroupID parameter as priority value
+
 func derefDataType(fieldType string) (DWORD, error) {
 	var dataType DWORD
 	switch fieldType {


### PR DESCRIPTION
I wanted to use this library for an arduino project.
But since it didn't include the `TransmitClientEvent` function I could only fetch data, not push.

So that's why I would like to add this function.